### PR TITLE
Check for identifier type for catalog number

### DIFF
--- a/packages/backend/src/services/specimenService/resources/specimen/operations/getMany/controller.js
+++ b/packages/backend/src/services/specimenService/resources/specimen/operations/getMany/controller.js
@@ -18,6 +18,7 @@ module.exports = function getMany({ operation, elasticModels }) {
     let body = {}
     if (filter && filter.catalogNumber) {
       body = bodybuilder()
+        .filter('match', 'identifiers.type', 'catalogNumber')
         .filter('match', 'identifiers.value', filter.catalogNumber)
         .size(limit)
         .from(offset)


### PR DESCRIPTION
This is not fully working as intended with the current elastic search
mappings but will be fixed once the mappings are updated.