### PR TITLE
Align behavior on creating new record of any type

### DIFF
--- a/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createResourceManagerWrapper.js
+++ b/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createResourceManagerWrapper.js
@@ -636,12 +636,7 @@ const createResourceManagerWrapper = () => ComposedComponent => {
       log.debug(`Got interaction: ${type}`, data)
       switch (type) {
         case CREATE_SUCCESS: {
-          const { tableActive } = this.props
-
-          if (tableActive) {
-            this.tableSearch()
-          }
-
+          this.tableSearch()
           break
         }
         default: {
@@ -694,6 +689,7 @@ const createResourceManagerWrapper = () => ComposedComponent => {
       } = this.props
 
       if (!tableActive) {
+        this.tableSearch()
         return
       }
       // assume initialMount
@@ -835,8 +831,6 @@ const createResourceManagerWrapper = () => ComposedComponent => {
     }
     transitionToEditItemView() {
       log.debug('transition to view: EditItem')
-      const { filterValues } = this.props
-      this.tableSearch(filterValues)
     }
     transitionFromEditItemView() {
       log.debug('transition from view: EditItem')

--- a/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createResourceManagerWrapper.js
+++ b/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createResourceManagerWrapper.js
@@ -675,8 +675,8 @@ const createResourceManagerWrapper = () => ComposedComponent => {
         query,
         sort: sortOrder,
         useScroll: false,
-      }).then(prefetchItems => {
-        this.props.setListItems(prefetchItems, { managerScope })
+      }).then(items => {
+        this.props.setListItems(items, { managerScope })
 
         return null
       })

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/MainColumn/RecordForm/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/MainColumn/RecordForm/index.js
@@ -139,7 +139,7 @@ class RecordForm extends Component {
               `/app/specimens/mammals/${specimenId}/edit/sections/${match.params
                 .sectionId || '0'}`
             )
-          }, 1000)
+          }, 1500)
         }
       })
       .catch(handleReduxFormSubmitError)

--- a/packages/ui/src/domainModules/taxon/components/ScientificNamesTable/NewTaxonNameRow.js
+++ b/packages/ui/src/domainModules/taxon/components/ScientificNamesTable/NewTaxonNameRow.js
@@ -18,9 +18,11 @@ export class NewTaxonNameRow extends Component {
   }
 
   handleChange(itemId) {
-    this.props.onInteraction(ADD_SYNONYM, {
-      itemId,
-    })
+    if (itemId) {
+      this.props.onInteraction(ADD_SYNONYM, {
+        itemId,
+      })
+    }
   }
 
   render() {

--- a/packages/ui/src/domainModules/taxon/components/ScientificNamesTable/index.js
+++ b/packages/ui/src/domainModules/taxon/components/ScientificNamesTable/index.js
@@ -67,6 +67,15 @@ export class ScientificNamesTable extends Component {
     this.addSynonym = this.addSynonym.bind(this)
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (
+      this.props.scientificNames.length > 0 &&
+      nextProps.scientificNames.length === 0
+    ) {
+      this.setState({ connectingScientificName: true })
+    }
+  }
+
   setTaxonNameAsAccepted({ itemId } = {}) {
     const currentAcceptedName = this.props.acceptedTaxonName
 
@@ -178,21 +187,21 @@ export class ScientificNamesTable extends Component {
 
     return (
       <React.Fragment>
-        {(scientificNames.length > 0 || connectingScientificName) && (
-          <Table celled>
-            <Table.Header>
-              <Table.Row>
-                <Table.HeaderCell width={6}>
-                  <span className="required asterisk">Name</span>
-                </Table.HeaderCell>
-                <Table.HeaderCell>Rank</Table.HeaderCell>
-                <Table.HeaderCell>RUBIN no.</Table.HeaderCell>
-                <Table.HeaderCell>Status</Table.HeaderCell>
-                <Table.HeaderCell>Actions</Table.HeaderCell>
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {scientificNames.map(taxonItem => {
+        <Table celled>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell width={6}>
+                <span className="required asterisk">Name</span>
+              </Table.HeaderCell>
+              <Table.HeaderCell>Rank</Table.HeaderCell>
+              <Table.HeaderCell>RUBIN no.</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+              <Table.HeaderCell>Actions</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {scientificNames.length > 0 &&
+              scientificNames.map(taxonItem => {
                 return (
                   <TaxonNameRow
                     itemId={taxonItem.id}
@@ -203,15 +212,14 @@ export class ScientificNamesTable extends Component {
                   />
                 )
               })}
-              {connectingScientificName && (
-                <NewTaxonNameRow
-                  isFirstName={scientificNames.length === 0}
-                  onInteraction={this.handleInteraction}
-                />
-              )}
-            </Table.Body>
-          </Table>
-        )}
+            {connectingScientificName && (
+              <NewTaxonNameRow
+                isFirstName={scientificNames.length === 0}
+                onInteraction={this.handleInteraction}
+              />
+            )}
+          </Table.Body>
+        </Table>
         {!connectingScientificName && (
           <AddButton
             id="connect-scientific-name"

--- a/packages/ui/src/domainModules/taxon/components/TaxonManager/item/BaseForm/unitSpecs/taxonRoot/index.js
+++ b/packages/ui/src/domainModules/taxon/components/TaxonManager/item/BaseForm/unitSpecs/taxonRoot/index.js
@@ -12,6 +12,7 @@ const parts = [
       columnProps: { width: 14 },
     },
     name: 'parent.id',
+    required: true,
     wrapInField: true,
   },
 ]


### PR DESCRIPTION
This PR aligns the resourceManager with specimen mammals when it comes to showing all records on creating a new record and loading all records when entering a manager, regardless if it is the table view.

To further decrease the risk that a user creates a new mammal record and goes to the table before the new record has been added to elasticsearch, the loading time before opening the edit form is increased to 1500 ms.

The PR also contains a few bug fixes.

Tickets:

* https://trello.com/c/2h49PslH/994-show-all-records-after-creating-new-non-specimen-record
* https://trello.com/c/FidB5J9v/918-a-new-specimen-record-isnt-visible-in-table-view
* https://trello.com/c/fBZwjvDa/997-parent-is-missing-red-asterisk-in-taxon-form
* https://trello.com/c/kIapk77x/996-after-undo-changes-on-new-taxon-connected-scientific-names-is-closed