### PR TITLE
Fix elastic index not updated in time

### DIFF
--- a/packages/backend/src/lib/models/factories/elasticsearch/documentModel/methods/delFactory.js
+++ b/packages/backend/src/lib/models/factories/elasticsearch/documentModel/methods/delFactory.js
@@ -5,7 +5,9 @@ const log = createLog(
   'lib/elasticsearch/modelFactories/normalizedElasticModel/methods/delFactory'
 )
 
-module.exports = function delFactory({ Model, elasticsearch, getById } = {}) {
+module.exports = function delFactory(
+  { Model, elasticsearch, getById, forceRefresh } = {}
+) {
   if (!Model) {
     throw new Error('Have to provide model')
   }
@@ -18,8 +20,7 @@ module.exports = function delFactory({ Model, elasticsearch, getById } = {}) {
         .delete({
           id,
           index: Model.index,
-          // refresh: !config.env.isProduction,
-          refresh: false,
+          refresh: forceRefresh,
           type: Model.name,
         })
         .then(() => {

--- a/packages/backend/src/lib/models/factories/elasticsearch/documentModel/setupMethods.js
+++ b/packages/backend/src/lib/models/factories/elasticsearch/documentModel/setupMethods.js
@@ -33,7 +33,7 @@ module.exports = function setupMethods({ elasticsearch, Model, forceRefresh }) {
   })
   const create = createFactory({
     elasticsearch,
-    forceRefresh,
+    forceRefresh: true,
     Model,
   })
 
@@ -53,13 +53,14 @@ module.exports = function setupMethods({ elasticsearch, Model, forceRefresh }) {
 
   const del = delFactory({
     elasticsearch,
+    forceRefresh: true,
     getById,
     Model,
   })
 
   const update = updateFactory({
     elasticsearch,
-    forceRefresh,
+    forceRefresh: true,
     Model,
   })
 

--- a/packages/backend/src/services/specimenService/resources/specimen/data/postHooks/index.js
+++ b/packages/backend/src/services/specimenService/resources/specimen/data/postHooks/index.js
@@ -14,7 +14,7 @@ const indexHook = ({ item, serviceInteractor }) => {
         },
       },
     }
-    return serviceInteractor.requestUpdateView({
+    return serviceInteractor.updateView({
       request,
       resource: 'searchSpecimen',
     })

--- a/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
+++ b/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
@@ -134,22 +134,15 @@ const createHandleDelete = () => ComposedComponent => {
       const { del } = crudActionCreators[resource]
 
       return dispatch(del({ id: itemId })).then(() => {
-        const notification =
-          resource === 'specimen' // special case for specimen to wait for elasticsearch to update
-            ? {
-                componentProps: {
-                  description: 'Please wait while the table is updated...',
-                  header: 'The specimen was deleted',
-                },
-                ttl: 3000,
-                type: 'SUCCESS',
-              }
-            : {
-                componentProps: {
-                  header: 'The record was deleted',
-                },
-                type: 'SUCCESS',
-              }
+        const notification = {
+          componentProps: {
+            header:
+              resource === 'specimen'
+                ? 'The specimen was deleted'
+                : 'The record was deleted',
+          },
+          type: 'SUCCESS',
+        }
 
         createNotification(notification)
         fetchResourceCount()

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/MainColumn/RecordForm/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/MainColumn/RecordForm/index.js
@@ -139,7 +139,7 @@ class RecordForm extends Component {
               `/app/specimens/mammals/${specimenId}/edit/sections/${match.params
                 .sectionId || '0'}`
             )
-          }, 1500)
+          })
         }
       })
       .catch(handleReduxFormSubmitError)

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
@@ -350,11 +350,11 @@ class MammalManager extends Component {
             SPECIMENS_MAMMALS_TABLE_COLUMNS_SORTING,
             [{ name: 'idNumeric', sort: 'asc' }]
           )
-        }, 2000)
+        })
         break
       }
       case DEL_SUCCESS: {
-        setTimeout(() => this.handleSearchSpecimens(), 3000)
+        setTimeout(() => this.handleSearchSpecimens())
         break
       }
       default: {


### PR DESCRIPTION
Now we use the sync option in elasticsearch when doing crud operations (non batch). We also do the elasticsearch update as a part of the crud request instead of doing it detached. This will make it easier to update to frontend after ex adding a new specimen. It has performance implications but with the low volume of crud its likely not an issue