### PR TITLE
Fix navigation issue after creating and deleting

### DIFF
--- a/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
+++ b/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
@@ -81,7 +81,6 @@ const createHandleDelete = () => ComposedComponent => {
         })
       ).then(res => {
         const { relationships } = res || {}
-        this.setState({ loadingDelete: false })
         return this.deleteItemOrShowRelationships(relationships)
       })
     }
@@ -112,7 +111,7 @@ const createHandleDelete = () => ComposedComponent => {
 
         if (!relationshipsAreEmpty) {
           this.setState({ relationships })
-
+          this.setState({ loadingDelete: false })
           return createNotification({
             componentProps: {
               /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
@@ -153,6 +152,9 @@ const createHandleDelete = () => ComposedComponent => {
 
         createNotification(notification)
         fetchResourceCount()
+        setTimeout(() => {
+          this.setState({ loadingDelete: false })
+        }, 2000)
 
         if (onInteraction) {
           onInteraction(DEL_SUCCESS)

--- a/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
+++ b/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
@@ -153,7 +153,7 @@ const createHandleDelete = () => ComposedComponent => {
         fetchResourceCount()
         setTimeout(() => {
           this.setState({ loadingDelete: false })
-        }, 3000)
+        }, 2000)
 
         if (onInteraction) {
           onInteraction(DEL_SUCCESS)

--- a/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
+++ b/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
@@ -134,15 +134,22 @@ const createHandleDelete = () => ComposedComponent => {
       const { del } = crudActionCreators[resource]
 
       return dispatch(del({ id: itemId })).then(() => {
-        const notification = {
-          componentProps: {
-            header:
-              resource === 'specimen'
-                ? 'The specimen was deleted'
-                : 'The record was deleted',
-          },
-          type: 'SUCCESS',
-        }
+        const notification =
+          resource === 'specimen'
+            ? {
+                componentProps: {
+                  description: 'Please wait while the table is updated...',
+                  header: 'The specimen was deleted',
+                },
+                ttl: 3000,
+                type: 'SUCCESS',
+              }
+            : {
+                componentProps: {
+                  header: 'The record was deleted',
+                },
+                type: 'SUCCESS',
+              }
 
         createNotification(notification)
         fetchResourceCount()

--- a/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
+++ b/packages/ui/src/coreModules/resourceManager/components/ResourceManager/MainColumn/item/ActionBars/higherOrderComponents/createHandleDelete/index.js
@@ -110,8 +110,7 @@ const createHandleDelete = () => ComposedComponent => {
         )
 
         if (!relationshipsAreEmpty) {
-          this.setState({ relationships })
-          this.setState({ loadingDelete: false })
+          this.setState({ loadingDelete: false, relationships })
           return createNotification({
             componentProps: {
               /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
@@ -154,7 +153,7 @@ const createHandleDelete = () => ComposedComponent => {
         fetchResourceCount()
         setTimeout(() => {
           this.setState({ loadingDelete: false })
-        }, 2000)
+        }, 3000)
 
         if (onInteraction) {
           onInteraction(DEL_SUCCESS)

--- a/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createResourceManagerWrapper.js
+++ b/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createResourceManagerWrapper.js
@@ -23,6 +23,7 @@ import { KeyboardShortcuts } from 'coreModules/keyboardShortcuts/components'
 import {
   CLOSE_ITEM_VIEW,
   CREATE_SUCCESS,
+  DEL_SUCCESS,
   ITEM_SELECT,
   NAVIGATE_CREATE,
   NAVIGATE_FILTER,
@@ -656,6 +657,10 @@ const createResourceManagerWrapper = () => ComposedComponent => {
       log.debug(`Got interaction: ${type}`, data)
       switch (type) {
         case CREATE_SUCCESS: {
+          this.tableSearch()
+          break
+        }
+        case DEL_SUCCESS: {
           this.tableSearch()
           break
         }

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/MainColumn/CreateSpecimen/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/MainColumn/CreateSpecimen/index.js
@@ -94,7 +94,11 @@ class CreateSpecimen extends PureComponent {
           return createSpecimen({ item }).then(res => {
             fetchResourceCount()
             onInteraction(CREATE_SUCCESS, { itemId: res.id })
-            return res
+            return new Promise(resolve => {
+              setTimeout(() => {
+                return resolve(res)
+              }, 3000)
+            })
           })
         }}
         initialValues={initialValues}

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
@@ -389,7 +389,7 @@ class MammalManager extends Component {
                     this.props.searchResult.items.length
                   )
                 )
-              }, 3000)
+              })
             }
           }
         )

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
@@ -382,7 +382,13 @@ class MammalManager extends Component {
             if (!isTableView) {
               setTimeout(() => {
                 this.handleOpenTableView()
-                this.handleSetCurrentTableRowNumber(null, currentTableRowNumber)
+                this.handleSetCurrentTableRowNumber(
+                  null,
+                  Math.min(
+                    currentTableRowNumber,
+                    this.props.searchResult.items.length
+                  )
+                )
               }, 3000)
             }
           }

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
@@ -375,7 +375,18 @@ class MammalManager extends Component {
         break
       }
       case DEL_SUCCESS: {
-        setTimeout(() => this.handleSearchSpecimens())
+        const { currentTableRowNumber, isTableView } = this.props
+
+        this.handleSearchSpecimens(undefined, { openTableView: false }).then(
+          () => {
+            if (!isTableView) {
+              setTimeout(() => {
+                this.handleOpenTableView()
+                this.handleSetCurrentTableRowNumber(null, currentTableRowNumber)
+              }, 3000)
+            }
+          }
+        )
         break
       }
       default: {


### PR DESCRIPTION
This is a very temporary solution until we can refactor the resource manager. In the refactor ofc all setTimeouts should be removed.

This should fix the issue that you could fast navigate to the specimen list and land on the wrong specimen. It should fix landing on wrong record after making a delete of a specimen. It should also fix non specimen entries not removed from the list (and kept in a loading state) after you delete them