### PR TITLE
Fix record event times, filter open-close effects, keyboard shortcuts bug and storage dropdown text

### DIFF
--- a/packages/common/es5/storage/extractNameWithFirstLevelParent.js
+++ b/packages/common/es5/storage/extractNameWithFirstLevelParent.js
@@ -1,22 +1,20 @@
 'use strict';
 
 var _require = require('../constants/storage'),
+    LEVEL_INSTITUTION = _require.LEVEL_INSTITUTION,
     LEVEL_ROOM = _require.LEVEL_ROOM;
 
 var extractNameWithFirstLevelParent = function extractNameWithFirstLevelParent(nestedStorageLocation) {
   if (!nestedStorageLocation) {
     return '';
   }
-
   var group = nestedStorageLocation.group,
       name = nestedStorageLocation.name;
 
-  if (group === LEVEL_ROOM) {
-    return name;
+  if (group === LEVEL_INSTITUTION || group === LEVEL_ROOM) {
+    return name + ' [' + group + ']';
   }
-
   var parentName = extractNameWithFirstLevelParent(nestedStorageLocation.parent);
   return name + ' [' + group + ' in ' + parentName + ']';
 };
-
 module.exports = extractNameWithFirstLevelParent;

--- a/packages/ui/src/coreModules/layout/higherOrderComponents/createApplicationLayer.js
+++ b/packages/ui/src/coreModules/layout/higherOrderComponents/createApplicationLayer.js
@@ -8,11 +8,11 @@ import { actionCreators } from '../keyObjectModule'
 import { APPLICATION_LAYER_VIEW, APPLICATION_LAYER_MODAL } from '../constants'
 
 const contextTypes = {
-  layer: PropTypes.string,
+  applicationLayer: PropTypes.string,
 }
 
 const childContextTypes = {
-  layer: PropTypes.string.isRequired,
+  applicationLayer: PropTypes.string.isRequired,
 }
 
 const propTypes = {
@@ -35,7 +35,7 @@ export default function createApplicationLayer({ layer }) {
     class ApplicationLayer extends Component {
       getChildContext() {
         return {
-          layer: this.props.layer,
+          applicationLayer: this.props.layer,
         }
       }
       componentWillMount() {
@@ -43,7 +43,7 @@ export default function createApplicationLayer({ layer }) {
       }
 
       componentWillUnmount() {
-        const parentLayer = this.context.layer
+        const parentLayer = this.context.applicationLayer
         this.props.setApplicationLayer(parentLayer || '')
       }
 

--- a/packages/ui/src/coreModules/resourceManager/components/ResourceManager/FilterColumn/BottomBar/index.js
+++ b/packages/ui/src/coreModules/resourceManager/components/ResourceManager/FilterColumn/BottomBar/index.js
@@ -38,7 +38,8 @@ class BottomBar extends PureComponent {
 
   handleReset(event) {
     event.preventDefault()
-    this.props.onShowAllRecords()
+    const { isPicker } = this.props
+    this.props.onShowAllRecords({ isPicker })
   }
 
   handleSubmit(event) {

--- a/packages/ui/src/coreModules/resourceManager/components/ResourceManager/FilterColumn/BottomBar/index.js
+++ b/packages/ui/src/coreModules/resourceManager/components/ResourceManager/FilterColumn/BottomBar/index.js
@@ -69,7 +69,7 @@ class BottomBar extends PureComponent {
             size={isPicker ? 'small' : 'large'}
             style={{ float: 'right' }}
           >
-            {isPicker ? 'Clear filters' : 'Clear all filters'}
+            {isPicker ? 'Show all' : 'Clear all filters'}
           </Button>
         </Grid.Column>
       </Grid>

--- a/packages/ui/src/coreModules/resourceManager/components/ResourceManager/FilterColumn/BottomBar/index.js
+++ b/packages/ui/src/coreModules/resourceManager/components/ResourceManager/FilterColumn/BottomBar/index.js
@@ -64,7 +64,7 @@ class BottomBar extends PureComponent {
           </Button>
           <Button
             basic
-            disabled={pristine}
+            disabled={pristine && !isPicker}
             onClick={this.handleReset}
             size={isPicker ? 'small' : 'large'}
             style={{ float: 'right' }}

--- a/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createNavigationState.js
+++ b/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createNavigationState.js
@@ -118,6 +118,7 @@ const createResourceUrlState = () => ComposedComponent => {
 
     navigateEdit(itemId) {
       this.props.updateState({
+        filterColumn: '',
         itemId,
         mainColumn: 'edit',
       })

--- a/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createNavigationState.js
+++ b/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createNavigationState.js
@@ -127,6 +127,7 @@ const createResourceUrlState = () => ComposedComponent => {
     navigateFilter() {
       this.props.updateState({
         filterColumn: 'filter',
+        mainColumn: 'table',
       })
     }
 

--- a/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createResourceManagerWrapper.js
+++ b/packages/ui/src/coreModules/resourceManager/higherOrderComponents/createResourceManagerWrapper.js
@@ -590,13 +590,15 @@ const createResourceManagerWrapper = () => ComposedComponent => {
         })
       }
     }
-    handleShowAllRecords() {
+    handleShowAllRecords({ isPicker }) {
       const { managerScope, showAll, treeActive } = this.props
 
       if (treeActive) {
         this.props.setShowAll(!showAll, { managerScope })
       } else {
-        this.resetFilters()
+        if (!isPicker) {
+          this.resetFilters()
+        }
         this.tableSearch()
       }
     }

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
@@ -467,6 +467,11 @@ class MammalManager extends Component {
 
   handleToggleFilters(event) {
     event.preventDefault()
+
+    if (!this.props.filterColumnIsOpen) {
+      this.handleOpenTableView(event)
+    }
+
     this.props.setFilterColumnIsOpen(!this.props.filterColumnIsOpen)
   }
 

--- a/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
+++ b/packages/ui/src/domainModules/collectionMammals/components/MammalManager/index.js
@@ -551,6 +551,7 @@ class MammalManager extends Component {
   handleOpenEditRecordView(event) {
     if (event) event.preventDefault()
 
+    this.props.setFilterColumnIsOpen(false)
     const specimenId = this.props.focusedSpecimenId
     if (specimenId) {
       this.props.push(`/app/specimens/mammals/${specimenId}/edit/sections/0`)


### PR DESCRIPTION
- Fix and improve record event times: Make them show up properly and make catalog date the registration date for a new record, unless the user has entered a cataloged date manually.
- Close specimen filter when going to specimen form, and open table when opening specimen filter
- Fix keyboard shortcuts in geography, storage, taxon after opening picker for parent in form
- Fix text in storage location dropdown, so that room shows after e.g. Bensalen [room]
- Rename Clear filters => Show all in picker filter and align behavior with renaming