### PR TITLE
Configure formatting of markdown

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "proseWrap": "always",
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5"

--- a/packages/backend/.prettierrc
+++ b/packages/backend/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "proseWrap": "always",
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5"

--- a/packages/common/.prettierrc
+++ b/packages/common/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "proseWrap": "always",
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5"

--- a/packages/migrations/.prettierrc
+++ b/packages/migrations/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "proseWrap": "always",
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5"

--- a/packages/models/.prettierrc
+++ b/packages/models/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "proseWrap": "always",
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5"

--- a/packages/scripts/.prettierrc
+++ b/packages/scripts/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "proseWrap": "always",
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5"

--- a/packages/ui/.prettierrc
+++ b/packages/ui/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "proseWrap": "always",
   "semi": false,
   "singleQuote": true,
   "trailingComma": "es5"


### PR DESCRIPTION
"One of Prettier's core features is its ability to wrap code at a
specified line length. This applies to Markdown too, which means you can
maintain nice and clean 80-character-wide Markdown files without having
to re-adjust line breaks manually when you add or delete words."

https://prettier.io/blog/2017/11/07/1.8.0.html#markdown-support